### PR TITLE
Add a couple of helpers

### DIFF
--- a/src/Decoder.ml
+++ b/src/Decoder.ml
@@ -87,6 +87,16 @@ let alt decoder1 decoder2 json =
 
 let ( <|> ) = alt
 
+(* Helpers *)
+
+let fromOption ?(error = "invalid value") = function
+  | Some value -> pure value
+  | None -> throwError error
+
+let fromResult = function
+  | Ok value -> pure value
+  | Error error -> throwError error
+
 (* Decode string helpers *)
 
 let decodeString string decoder =

--- a/tests/Decoder_test.ml
+++ b/tests/Decoder_test.ml
@@ -266,4 +266,25 @@ let () =
                 ] (fun input ->
                   match input --> (right <|> left) with
                   | Ok _ -> fail "got a oneOf"
-                  | Error _ -> pass))))
+                  | Error _ -> pass)));
+
+      describe "Helpers" (fun () ->
+          describe "fromOption" (fun () ->
+              testAll "successfully convert an option into a decoder"
+                [ (Some "foo", Ok "foo"); (None, Error "invalid value") ]
+                (fun (option, expected) ->
+                  expect ("0" --> fromOption option) = expected);
+
+              testAll
+                "successfully convert an option into a decoder, with a custom \
+                 error"
+                [
+                  (Some "foo", "error", Ok "foo"); (None, "error", Error "error");
+                ] (fun (option, error, expected) ->
+                  expect ("0" --> fromOption ~error option) = expected));
+
+          describe "fromResult" (fun () ->
+              testAll "successfully convert an option into a decoder"
+                [ (Ok "foo", Ok "foo"); (Error "failed", Error "failed") ]
+                (fun (result, expected) ->
+                  expect ("0" --> fromResult result) = expected))))


### PR DESCRIPTION
`fromOption` and `fromResult` to ease integration with existing validation workflows based on core types